### PR TITLE
fix validation current quantity and max quantity

### DIFF
--- a/src/actions/cart.ts
+++ b/src/actions/cart.ts
@@ -95,5 +95,5 @@ export async function addToCart ({ productId, quantity }: addToCartParams): Prom
 }
 
 function getIsMaxQuantityReached (currentQuantity: number, maxQuantity: number) {
-  return currentQuantity >= maxQuantity
+  return currentQuantity > maxQuantity
 }


### PR DESCRIPTION
Arreglar la validación en el action carts cuando valida la cantidad maxima de productos por carrito, debe ser mayor que en vez de mayor o igual que